### PR TITLE
LangChain Broken Link Fix

### DIFF
--- a/KnowledgeGraph-Q&A-and-RAG-with-TabularData/README.md
+++ b/KnowledgeGraph-Q&A-and-RAG-with-TabularData/README.md
@@ -83,7 +83,7 @@ python src/app.py
 - Medical reports dataset: [Link](https://github.com/neo4j-partners/neo4j-generative-ai-azure/tree/main/ingestion/data)
 
 ## Key frameworks/libraries used in this chatbot:
-- Langchain agents: [Website](https://python.langchain.com/docs/use_cases/graph/quickstart/)
+- Langchain agents: [Website](https://python.langchain.com/v0.1/docs/use_cases/graph/quickstart/)
 - Gradio: [Documentation](https://www.gradio.app/docs/interface)
 - OpenAI: [Developer quickstart](https://platform.openai.com/docs/quickstart?context=python)
 - Neo4j: [Welcome to Neo4j](https://neo4j.com/docs/getting-started/)


### PR DESCRIPTION
Replace the docs link https://python.langchain.com/docs/use_cases/graph/quickstart/ 


with https://python.langchain.com/v0.1/docs/use_cases/graph/quickstart/

as it gives:

Page Moved
You can find the new location here.

Alternative pages

Please contact the owner of the site that linked you to the original URL and let them know their link has moved.